### PR TITLE
Add DHCPv6 Options Calculation Frame

### DIFF
--- a/IP_MAP_Calculator.py
+++ b/IP_MAP_Calculator.py
@@ -197,7 +197,7 @@ bin_display_col2 = [
     sg.Text('EA Length:', font=('Helvetica', 13, 'bold'),
       pad=((0, 14), (5, 0))),
 #    sg.Sizer(h_pixels=5, v_pixels=0),
-    sg.Slider(range=(0, 32), default_value=32, orientation='h',
+    sg.Slider(range=(0, 32), default_value=32, orientation='h', # Per RFC 7598 (dhcp) 0-48 is valid.
     disable_number_display=False, enable_events=True,
     size=(19, 8), trough_color='white', font=('Helvetica', 13, 'bold'),
     text_color=None, disabled=True, key='-EA_LEN_SLDR-'),
@@ -311,7 +311,15 @@ bin_display_layout = [
    [sg.Column(bin_display_col3, expand_x=True)],
 ]
 
-# Binary Display (4th frame)
+# DHCP Display (4th frame)
+#-------------------------------------#
+dhcp_layout = [
+   [sg.Text('dhcp line 1')],
+   [sg.Text('dhcp line 2')]
+]
+
+
+# Binary Display (5th frame)
 #-------------------------------------#
 button_col1 = [
    [sg.Button('Example', font='Helvetica 11', key='-EXAMPLE-'),
@@ -327,7 +335,7 @@ button_layout = [
    [sg.Column(button_col1, expand_x=True)]
 ]
 
-# Saved rule string frame (5th frame)
+# Saved rule string frame (6th frame)
 #-------------------------------------#
 #MLINE_SAVED = '-MLINE_SAVED-'+sg.WRITE_ONLY_KEY
 saved_section_layout = [
@@ -349,6 +357,7 @@ sections_layout = [
     expand_x=True, border_width=6, relief='ridge')],
    [sg.Frame('', bin_display_layout, expand_x=True, border_width=6,
     relief='ridge')],
+   [sg.Frame('', dhcp_layout, expand_x=True, border_width=6, relief='ridge')],
    [sg.Frame('', button_layout, expand_x=True, border_width=6,
     relief='ridge')],
    [sg.Frame('Saved Rule Strings', saved_section_layout, expand_x=True,
@@ -907,13 +916,20 @@ class UserPd:
       self.lastpd = ''
 
    def new_pd(self):
+      print('\n------Begin User PD test output------')
+      print('in new_pd')      
       if self.plist == self.last_plist:  # Next PD from current PD object
+         print('in plist == last_plist')
          nextpd = next(self.pd_obj)
          self.lastpd = nextpd
          return nextpd
       else:                              # New PD object & new PD
+         print('in plist != last_plist')
          self.last_plist = self.plist
+         for index, value in enumerate(self.plist):
+            print(index, value)
          bmr_v6p = ip.ip_network('/'.join((self.plist[1], str(self.plist[2]))))
+         print(f'bmr_v6p is {bmr_v6p}')
          pd_len = int(self.plist[2]) + int(self.plist[5])
          self.pd_obj = bmr_v6p.subnets(new_prefix = pd_len)
          nextpd = next(self.pd_obj)
@@ -986,6 +1002,7 @@ def validate(param_ls):
    # test IPv6 prefix/mask
    try:
       v6p_out = ip.ip_network('/'.join((v6p, str(v6pl))))
+      print(v6p_out)
       validflag = 'pass'
    except:
       advance('-R6PRE-')

--- a/IP_MAP_Calculator.py
+++ b/IP_MAP_Calculator.py
@@ -290,7 +290,7 @@ bin_display_col2 = [
     sg.Slider(range=(0, 0), default_value=0, orientation='h',
     disable_number_display=False, enable_events=True,
     size=(42, 8), trough_color='white', font=('Helvetica', 14, 'bold'),
-    pad=((5, 10), (0, 10)), key='-V4HOST_SLDR-'),
+    pad=((5, 10), (0, 0)), key='-V4HOST_SLDR-'),
     sg.Button(' + 1', font='Helvetica 11', key='-NEXT_HOST-'),
    ],
 ]
@@ -320,11 +320,10 @@ dhcp_layout = [
    [sg.Text('DMR:', font=(None, 13, 'bold')),
     sg.Input('Ex. 2001:db8:ffff::/64', background_color='#fdfdfc',
       border_width=2, disabled=True, key='DMR_INPUT'),
-    sg.Button('Enter', key='DMR_ENTER'),
-    # sg.Push(),
-    sg.Checkbox('FMR', font=('Helvetica', 13, 'bold'), tooltip=fmr_tooltip,
-      enable_events=True, key='FMR_FLAG')],
+    sg.Button('Enter', key='DMR_ENTER')],
    [sg.Text('S46 MAP-T Container Option 95:', font=('Helvetica', 13, 'bold')),
+    sg.Checkbox('FMR String', font=('Helvetica', 13, 'bold'), tooltip=fmr_tooltip,
+      enable_events=True, key='FMR_FLAG'),
     sg.Text('', text_color='red', font='None 14 bold', key='-DHCP_MESSAGES-')],
    [sg.Sizer(4, 0),
     sg.Input('', justification='centered', size=(85, 1), disabled=True,
@@ -1143,7 +1142,6 @@ def validate(param_ls):
    # test IPv6 prefix/mask
    try:
       v6p_out = ip.ip_network('/'.join((v6p, str(v6pl))))
-      print(v6p_out)
       validflag = 'pass'
    except:
       advance('-R6PRE-')
@@ -1535,7 +1533,7 @@ while True:
       if name in values["-MLINE_SAVED-"]:
          window['-PARAM_MESSAGES-'].update('Duplicate Rule Name')
       elif rule[rule.index('|'):] in values["-MLINE_SAVED-"]:
-         print(rule[rule.index('|'):])
+         # print(rule[rule.index('|'):])
          window['-PARAM_MESSAGES-'].update('Duplicate Rule')
       else:
          savstr = f'{values["-BMR_STRING_DSPLY-"]} ' \
@@ -1585,9 +1583,7 @@ while True:
 
       # FMR checkbox changes option string to FMR without re-clicking DMR Enter Button
       if event == 'FMR_FLAG' and values['OPT_95']: # New function test
-         print(f'fmr flag is {values["FMR_FLAG"]}, last flag is {last_fmr_flag}')
          if values['FMR_FLAG'] != last_fmr_flag:
-            print(f'flags are different - re-running dhcp_calc')
             window['OPT_95'].update('')
             window['OPT_89'].update('')
             window.read(timeout=50)
@@ -1597,7 +1593,9 @@ while True:
 
    print(f'#------- End Event {cntr - 1} -------#')
 
-   print('\n ---- VALUES KEYS ----')
+
+
+   # print('\n ---- VALUES KEYS ----')
    # values = [values[x] for x in values.keys()]
    # # for x in values():
    # print(values)
@@ -1620,3 +1618,4 @@ while True:
    '''
 
 window.close()
+ 

--- a/IP_MAP_Calculator.py
+++ b/IP_MAP_Calculator.py
@@ -8,7 +8,7 @@ import sys
 
 '''IP_MAP_Calculator.py: Calculates the results of IP MAP Rule parameters'''
 
-# IP_MAP_ADDRESS_CALCULATOR v0.11.16 - 10/25/2024 - D. Scott Freemire
+# IP_MAP_ADDRESS_CALCULATOR v0.12.00 - 11/13/2024 - D. Scott Freemire
 
 # Window theme and frame variables
 #-------------------------------------#
@@ -437,9 +437,6 @@ window['OPT_93'].Widget.config(readonlybackground='#fdfdfc',
    borderwidth=2)
 window['OPT_91'].Widget.config(readonlybackground='#fdfdfc',
    borderwidth=2)
-
-
-
 
 # Enable "Return" key to trigger Enter event in Rule String field
 # Bind events to text fields

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 David Scott Freemire
+Copyright (c) 2023-2024 David Scott Freemire
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/files/about_txt
+++ b/files/about_txt
@@ -1,4 +1,4 @@
-IP MAP Calculator v0.11.16 - 10/25/2024
+IP MAP Calculator v0.12.00 - 11/13/2024
 https://github.com/sfreemire/IP_MAP_Calculator
 
 License:


### PR DESCRIPTION
Added a new calculator section (frame) that will calculate the MAP-T Softwire 46 (S46) Options for MAP-T domain parameters currently displayed. This requires an additional value, the MAP-T DMR, to be entered. It also includes an option (checkbox) for modifying the options to be formatted as an "FMR" instead of a "BMR" (Forwarding Mapping Rule, instead of a Basic Mapping Rule).

The DHCPv6 output is cleared if the other MAP-T parameters are edited.